### PR TITLE
feat(vpn,raspberry): manage snx-rs VPN in dotfiles + Debian/RPi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 
 # Per-machine secrets (real file is local, example is in repo)
 dot_config/zsh/work.zsh
+dot_config/snx-rs/vpn.conf

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ My personal dotfiles, managed with [chezmoi](https://www.chezmoi.io/).
 Tested on:
 - **macOS** (Sonoma+)
 - **Arch Linux** (Hyprland + sddm)
+- **Raspberry Pi OS / Debian** (minimal headless CLI)
 
 ## Install on a new machine
 
@@ -22,15 +23,43 @@ This will:
 1. Clone the repo into `~/.local/share/chezmoi`.
 2. Run `run_once_before_*` scripts to install oh-my-zsh and its plugins.
 3. Render templates and write your `~/.zshrc`, `~/.config/...` files.
-4. Run `run_onchange_30-install-packages.sh` to install the packages from the manifest (`Brewfile` on macOS, `pacman` + AUR via `paru` on Arch).
+4. Run `run_onchange_30-install-packages.sh` to install the packages from the manifest (`Brewfile` on macOS, `pacman` + AUR via `paru` on Arch, `apt` on Debian/Raspberry Pi OS).
+5. On Linux, run `run_once_after_40-install-snx-rs.sh` to build the snx-rs VPN client from source if it isn't already present.
 
-After it finishes, copy and fill in the secrets template:
+After it finishes, copy and fill in the secrets templates:
 ```sh
 cp ~/.config/zsh/work.zsh.example ~/.config/zsh/work.zsh
 $EDITOR ~/.config/zsh/work.zsh
+
+cp ~/.config/snx-rs/vpn.conf.example ~/.config/snx-rs/vpn.conf
+$EDITOR ~/.config/snx-rs/vpn.conf
 ```
 
 Open a new terminal and you're done.
+
+## VPN (snx-rs)
+
+The `~/.local/bin/vpn` launcher starts the [snx-rs](https://github.com/ancwrd1/snx-rs)
+Check Point VPN client. Connection parameters (server, login type, user, routes
+to ignore) live in `~/.config/snx-rs/vpn.conf` — gitignored, copied from
+`vpn.conf.example`. `~/.local/bin/home-tmux.sh` runs the tunnel inside a detached
+`HOME` tmux session at login.
+
+`vpn` calls `sudo -n snx-rs`, so the binary needs passwordless sudo. Add a
+sudoers drop-in, e.g.:
+```sh
+echo "$USER ALL=(root) NOPASSWD: $(command -v snx-rs)" | sudo tee /etc/sudoers.d/snx-rs
+```
+
+`VPN_IGNORE_ROUTES` drops corporate routes that overlap local docker subnets,
+which would otherwise hijack host→container traffic.
+
+## Raspberry Pi / Debian
+
+Minimal headless CLI environment (shell, tmux, nvim, cli tools) installed via
+`apt` from `packages/debian-apt.txt`. `fd`/`bat` are symlinked from Debian's
+`fdfind`/`batcat`, and `eza` is installed from the maintainer's apt repo. The
+snx-rs VPN client is built from source for ARM by `run_once_after_40-install-snx-rs.sh`.
 
 ## Layout
 
@@ -44,18 +73,25 @@ dotfiles/
 │   │   ├── exports.zsh         # env vars + tool integrations
 │   │   ├── path.zsh            # PATH wiring + pyenv init
 │   │   └── work.zsh.example    # template for per-machine secrets
+│   ├── snx-rs/
+│   │   └── vpn.conf.example    # template for VPN connection params
 │   ├── nvim/                   # LazyVim
 │   ├── tmux/tmux.conf
 │   ├── ghostty/config.tmpl     # OS-templated (cmd+s on macOS, ctrl+s on Linux)
 │   ├── bat/, btop/, eza/, htop/, posting/
 │   └── hypr/                   # Hyprland — populated on Arch
+├── dot_local/bin/
+│   ├── executable_vpn          # snx-rs VPN launcher (reads ~/.config/snx-rs/vpn.conf)
+│   └── executable_home-tmux.sh # detached HOME tmux session running the tunnel
 ├── packages/
 │   ├── Brewfile
 │   ├── arch-pacman.txt
-│   └── arch-aur.txt
+│   ├── arch-aur.txt
+│   └── debian-apt.txt          # Raspberry Pi / Debian, minimal headless CLI
 ├── run_once_before_10-install-omz.sh.tmpl
 ├── run_once_before_20-install-omz-plugins.sh.tmpl
 ├── run_onchange_30-install-packages.sh.tmpl
+├── run_once_after_40-install-snx-rs.sh.tmpl   # build snx-rs from source on Linux
 └── docs/                       # spec + plan history
 ```
 
@@ -77,7 +113,9 @@ linux-only line
 
 ## Secrets
 
-Don't commit them. `~/.config/zsh/work.zsh` is gitignored. The example file (`work.zsh.example`) is committed as a template.
+Don't commit them. `~/.config/zsh/work.zsh` and `~/.config/snx-rs/vpn.conf` are
+gitignored. Their example files (`work.zsh.example`, `vpn.conf.example`) are
+committed as templates.
 
 ## Wallpapers
 

--- a/dot_config/snx-rs/vpn.conf.example
+++ b/dot_config/snx-rs/vpn.conf.example
@@ -1,0 +1,23 @@
+# snx-rs VPN connection parameters — sourced by ~/.local/bin/vpn.
+#
+# Copy this file to ~/.config/snx-rs/vpn.conf and fill in real values.
+# The example is committed to the dotfiles repo; the real vpn.conf is gitignored.
+
+# VPN gateway, "host" or "host:port" (default port 443).
+VPN_SERVER="vpn.example.com"
+
+# Authentication method, as advertised by the gateway (e.g. vpn_Xxx).
+VPN_LOGIN_TYPE="vpn_Xxx"
+
+# User name to authenticate with.
+VPN_USER="your_user"
+
+# Comma-separated routes (x.x.x.x/x) to ignore from the ones the gateway pushes.
+# Useful when corporate routes overlap local docker subnets. Leave empty to keep
+# all routes acquired from the server.
+VPN_IGNORE_ROUTES="172.20.0.0/16,172.21.0.0/23"
+
+# Path to the snx-rs binary. Leave empty to auto-detect from PATH.
+# On machines that build from source, e.g.:
+#   SNX_BIN="$HOME/github/snx-rs/target/release/snx-rs"
+SNX_BIN=""

--- a/dot_local/bin/executable_home-tmux.sh
+++ b/dot_local/bin/executable_home-tmux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Ensure a detached tmux session named HOME exists, with the VPN tunnel
+# running in its first window, then attach to it.
+# Launched at login / Hyprland startup (see ~/.config/hypr/hyprland.conf).
+set -u
+
+SESSION="HOME"
+TMUX_BIN="$(command -v tmux || echo /usr/bin/tmux)"
+VPN_CMD="$HOME/.local/bin/vpn"
+
+if ! "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; then
+    "$TMUX_BIN" new-session -d -s "$SESSION" -n vpn
+    "$TMUX_BIN" send-keys -t "$SESSION:vpn" "$VPN_CMD" C-m
+fi
+
+"$TMUX_BIN" attach-session -t "$SESSION"
+
+# If the session is killed or we detach, fall back to a login shell so the
+# terminal window stays usable instead of closing.
+exec "${SHELL:-/usr/bin/zsh}" -l

--- a/dot_local/bin/executable_vpn
+++ b/dot_local/bin/executable_vpn
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# snx-rs VPN launcher.
+#
+# Connection parameters live in ~/.config/snx-rs/vpn.conf (gitignored) — copy
+# vpn.conf.example there and fill in real values. This keeps corporate
+# identifiers out of the public dotfiles repo.
+#
+# VPN_IGNORE_ROUTES exists because some corporate routes overlap local docker
+# networks: host->container traffic would otherwise be pulled into the tunnel
+# and hang (TCP connect to published ports "succeeds" via docker-proxy, but no
+# data flows). Ignoring those subnets keeps local containers reachable.
+set -euo pipefail
+
+CONF="${XDG_CONFIG_HOME:-$HOME/.config}/snx-rs/vpn.conf"
+
+if [ ! -r "$CONF" ]; then
+    echo "Missing $CONF" >&2
+    echo "Copy ${CONF%/*}/vpn.conf.example to vpn.conf and fill it in." >&2
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$CONF"
+
+: "${VPN_SERVER:?set VPN_SERVER in $CONF}"
+: "${VPN_LOGIN_TYPE:?set VPN_LOGIN_TYPE in $CONF}"
+: "${VPN_USER:?set VPN_USER in $CONF}"
+
+# Resolve the snx-rs binary: explicit SNX_BIN, then PATH.
+SNX="${SNX_BIN:-}"
+[ -n "$SNX" ] || SNX="$(command -v snx-rs || true)"
+if [ -z "$SNX" ] || [ ! -x "$SNX" ]; then
+    echo "snx-rs binary not found. Set SNX_BIN in $CONF or install snx-rs." >&2
+    exit 1
+fi
+
+if pgrep -x snx-rs >/dev/null; then
+    echo "snx-rs already running (pid $(pgrep -x snx-rs | head -1))"
+    exit 0
+fi
+
+args=(-s "$VPN_SERVER" -o "$VPN_LOGIN_TYPE" -u "$VPN_USER" -X true -l info)
+if [ -n "${VPN_IGNORE_ROUTES:-}" ]; then
+    args+=(-I "$VPN_IGNORE_ROUTES")
+fi
+
+exec sudo -n "$SNX" "${args[@]}"

--- a/packages/debian-apt.txt
+++ b/packages/debian-apt.txt
@@ -1,0 +1,25 @@
+# Debian / Raspberry Pi OS packages (apt). Minimal headless CLI set.
+# One per line. Comments and blanks OK.
+#
+# Notes on naming/availability vs the Arch/Brew lists:
+#   - fd  is the `fd-find` package (binary `fdfind`) -> symlinked to `fd`
+#   - bat is the `bat` package      (binary `batcat`) -> symlinked to `bat`
+#   - eza is NOT in Debian repos    -> installed from the gierens apt repo
+#   - cbonsai / k9s / pyenv         -> not packaged; skipped on headless
+
+build-essential
+pkg-config
+curl
+git
+zsh
+neovim
+tmux
+fzf
+fd-find
+bat
+btop
+htop
+ripgrep
+thefuck
+zsh-autosuggestions
+zsh-syntax-highlighting

--- a/run_once_after_40-install-snx-rs.sh.tmpl
+++ b/run_once_after_40-install-snx-rs.sh.tmpl
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Build & install the snx-rs VPN client (CLI only) from source.
+# Runs on Linux; needed on machines without a packaged snx-rs (e.g. Raspberry
+# Pi / ARM). The GTK/WebKit GUI is skipped — headless only.
+set -eu
+
+{{ if eq .chezmoi.os "linux" -}}
+SNX_DIR="$HOME/github/snx-rs"
+RELEASE_BIN="$SNX_DIR/target/release/snx-rs"
+
+# Already on PATH? Nothing to do.
+if command -v snx-rs >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Built previously but not on PATH — just expose it.
+if [ -x "$RELEASE_BIN" ]; then
+  mkdir -p "$HOME/.local/bin"
+  ln -sf "$RELEASE_BIN" "$HOME/.local/bin/snx-rs"
+  [ -x "$SNX_DIR/target/release/snxctl" ] && \
+    ln -sf "$SNX_DIR/target/release/snxctl" "$HOME/.local/bin/snxctl"
+  exit 0
+fi
+
+echo "Installing snx-rs from source (CLI only)..."
+
+# Build dependencies: C toolchain + OpenSSL + SQLite.
+if [ -r /etc/arch-release ]; then
+  sudo pacman -S --needed --noconfirm base-devel openssl sqlite pkgconf git
+elif [ -r /etc/debian_version ] || command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y build-essential pkg-config libssl-dev libsqlite3-dev git
+fi
+
+# Rust toolchain (snx-rs needs Rust >= 1.88; rustup provides current stable).
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y
+  . "$HOME/.cargo/env"
+fi
+
+# Fetch sources into the conventional ~/github layout.
+if [ ! -d "$SNX_DIR/.git" ]; then
+  mkdir -p "$(dirname "$SNX_DIR")"
+  git clone https://github.com/ancwrd1/snx-rs.git "$SNX_DIR"
+fi
+
+# Build just the CLI client + controller (no GUI on headless).
+( cd "$SNX_DIR" && cargo build --release -p snx-rs -p snxctl )
+
+mkdir -p "$HOME/.local/bin"
+ln -sf "$RELEASE_BIN" "$HOME/.local/bin/snx-rs"
+ln -sf "$SNX_DIR/target/release/snxctl" "$HOME/.local/bin/snxctl"
+
+echo "snx-rs installed at $RELEASE_BIN (symlinked into ~/.local/bin)."
+{{- end }}

--- a/run_onchange_30-install-packages.sh.tmpl
+++ b/run_onchange_30-install-packages.sh.tmpl
@@ -1,5 +1,5 @@
 #!/bin/sh
-# packages hash: {{ include "packages/Brewfile" | sha256sum }} {{ include "packages/arch-pacman.txt" | sha256sum }} {{ include "packages/arch-aur.txt" | sha256sum }}
+# packages hash: {{ include "packages/Brewfile" | sha256sum }} {{ include "packages/arch-pacman.txt" | sha256sum }} {{ include "packages/arch-aur.txt" | sha256sum }} {{ include "packages/debian-apt.txt" | sha256sum }}
 set -eu
 
 {{ if eq .chezmoi.os "darwin" -}}
@@ -26,7 +26,31 @@ if [ -r /etc/arch-release ]; then
   fi
 
   paru -S --needed --noconfirm $(grep -Ev '^(#|$)' "$AUR_LIST")
+elif [ -r /etc/debian_version ] || command -v apt-get >/dev/null 2>&1; then
+  # Debian / Raspberry Pi OS — minimal headless CLI set.
+  APT_LIST="{{ .chezmoi.sourceDir }}/packages/debian-apt.txt"
+
+  sudo apt-get update
+  sudo apt-get install -y $(grep -Ev '^(#|$)' "$APT_LIST")
+
+  # Debian ships fd as `fdfind` and bat as `batcat`; the dotfiles' aliases use
+  # the upstream names. Expose them under ~/.local/bin.
+  mkdir -p "$HOME/.local/bin"
+  command -v fdfind >/dev/null 2>&1 && ln -sf "$(command -v fdfind)" "$HOME/.local/bin/fd"
+  command -v batcat >/dev/null 2>&1 && ln -sf "$(command -v batcat)" "$HOME/.local/bin/bat"
+
+  # eza is not in the Debian repos — install it from the maintainer's apt repo.
+  if ! command -v eza >/dev/null 2>&1; then
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://raw.githubusercontent.com/eza-community/eza/main/deb.asc \
+      | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" \
+      | sudo tee /etc/apt/sources.list.d/gierens.list >/dev/null
+    sudo chmod 0644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+    sudo apt-get update
+    sudo apt-get install -y eza || echo "eza install failed; ll/ls aliases will be degraded"
+  fi
 else
-  echo "Non-Arch Linux: skipping package install"
+  echo "Unsupported Linux distro: skipping package install"
 fi
 {{- end }}


### PR DESCRIPTION
snx-rs VPN:
- add executable_vpn launcher reading connection params from gitignored ~/.config/snx-rs/vpn.conf (corporate identifiers stay out of the repo), keeping the pgrep guard, sudo -n, and docker-overlap route ignoring
- add executable_home-tmux.sh (HOME tmux session running the tunnel)
- add vpn.conf.example template, gitignore the real vpn.conf

Raspberry Pi / Debian (minimal headless CLI):
- add packages/debian-apt.txt and an apt branch in the package installer (fd/bat symlinks, eza from the maintainer apt repo)
- add run_once_after_40-install-snx-rs.sh to build the snx-rs CLI from source on Linux/ARM when not already present